### PR TITLE
自動更新機能実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,30 +1,30 @@
 window.addEventListener('DOMContentLoaded', (function(){
   function buildHTML(message){
     if (message.image) {
-      var html = `<div class="message">
+      var html = `<div class="message" data-id="${message.id}">
                     <div class="message__info">
                       <p class="message__info__talker">
-                      ${message.name}
+                        ${message.name}
                       </p>
                       <p class="message__info__date">
-                      ${message.date}
+                        ${message.date}
                       </p>
                     </div>
                     <p class="message__text">
-                      <div>
-                      ${message.content}
+                      <div class="lower-message__content">
+                        ${message.content}
                       </div>
-                      ${message.image}
+                        <img class="lower-message__image" src="${message.image}">
                     </p>
                   </div>`
     }  else {
-        var html = `<div class="message">
+        var html = `<div class="message" data-id="${message.id}">
         <div class="message__info">
           <p class="message__info__talker">
-          ${message.name}
+            ${message.name}
           </p>
           <p class="message__info__date">
-          ${message.date}
+            ${message.date}
           </p>
         </div>
         <div class="message__text">
@@ -57,4 +57,25 @@ window.addEventListener('DOMContentLoaded', (function(){
       alert('メッセージ送信に失敗しました');
     })
   })
+  var reloadMessages = function() {
+    last_message_id =  $('.message').last().data('id');
+    $.ajax({
+      url: "api/messages",
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      var insertHTML = '';
+      $.each(messages, function(i, message) {
+        insertHTML += buildHTML(message)
+      });
+      $('.messages').append(insertHTML);
+      $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');
+    })
+    .fail(function() {
+      console.log('error');
+    });
+  };
+  setInterval(reloadMessages, 7000);
 }))

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -74,7 +74,7 @@ window.addEventListener('DOMContentLoaded', (function(){
       $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');
     })
     .fail(function() {
-      console.log('error');
+      alert('自動更新に失敗しました');
     });
   };
   setInterval(reloadMessages, 7000);

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,9 @@
+class Api::MessagesController < ApplicationController
+
+  def index
+    @group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = @group.messages.includes(:user).where("id > #{last_message_id}")
+  end
+  
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.date message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,3 @@
--# .message{"data-message-id": "#{message.id}"}
 .message{data: {id: message.id}}
   .message__info
     %p.message__info__talker

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,5 @@
-.message
+-# .message{"data-message-id": "#{message.id}"}
+.message{data: {id: message.id}}
   .message__info
     %p.message__info__talker
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -3,3 +3,4 @@ json.image  @message.image.url
 json.user_id  @message.user.id
 json.name  @message.user.name
 json.date @message.created_at.strftime("%Y/%m/%d %H:%M")
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,9 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
#what
新規メッセージを一定時間で取得し表示する機能を実装
メッセージへのID付与、取得、リロードの設定
https://gyazo.com/308847ff37045cbae47743900806ea3e
※メッセージ送信フォームやグループ一覧のビュー乱れはこの後のブランチで修正します。
#why
チャット機能のユーティリティ向上のため
